### PR TITLE
Use https for geoip db uri

### DIFF
--- a/lib/geoip.js
+++ b/lib/geoip.js
@@ -18,7 +18,7 @@ class GeoIP {
 			lifetime: 1000*60*60*24*7, // get new databaase every week
 			maxmindCache: 1000
 		});
-		this.dbUri = 'http://geolite.maxmind.com/download/geoip/database/'+this.options.source+'.tar.gz';
+		this.dbUri = 'https://geolite.maxmind.com/download/geoip/database/'+this.options.source+'.tar.gz';
 
 		this.loadedPromise = this.updateDB();
 	}


### PR DESCRIPTION
Better to use https in general, and the http URL has been failing quite often for me.